### PR TITLE
Refactor theme image visibility handling in CSS for improved clarity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "**/node_modules": true
   },
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll": true
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
   }
 }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ The repository has a local pre-commit workflow and GitHub Actions checks:
 
 The pull request workflow runs linting, type checks, and tests first. The dry-run build waits for those jobs to complete.
 
+## Versioning
+
+The site version starts at `2.0.0` for the second major version of the portfolio. `npm run prepare` installs a local pre-commit hook that runs `npm run precommit`: quality checks first, then `npm run version:bump`.
+
+The version bump script inspects staged changes and skips automatically when `package.json` already has a manually staged version change for the commit. If the manual bump forgot the lockfile, the hook aligns `package-lock.json` to that staged version.
+
+- **minor** for meaningful site content, structure, component, page, HTML, or public asset changes.
+- **patch** for smaller implementation, styling, metadata, script, workflow, config, utility, or test changes.
+- **none** for docs-only changes or version-only staged changes.
+- **major** only when explicitly requested for a mass change of the site's style and structure.
+
+Override the heuristic when needed:
+
+```bash
+SITE_VERSION_BUMP=major git commit
+SITE_VERSION_BUMP=minor git commit
+SITE_VERSION_BUMP=patch git commit
+SITE_VERSION_BUMP=none git commit
+```
+
 ## Deployment
 
 The GitHub Pages release workflow runs when changes merge into `main`. It builds the Vite app, uploads the generated `dist/` output, and deploys it to GitHub Pages.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-09
 
+- 🔢 Set the portfolio baseline to version 2.0.0 and added smart version bump tooling with explicit major-version control for full site redesigns.
 - ⚡ Migrated the site from Next.js to Vite.
 - 🧪 Added linting, type checking, tests, and dry-run builds for local pre-commit checks.
 - 🚦 Split GitHub Actions into pull request checks and GitHub Pages release workflows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manix84.github.io",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "manix84.github.io",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "classnames": "^2.5.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manix84.github.io",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -11,7 +11,9 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "precommit": "npm run lint && npm run typecheck && npm test && npm run build:dry-run",
+    "precommit:checks": "npm run lint && npm run typecheck && npm test && npm run build:dry-run",
+    "precommit": "npm run precommit:checks && npm run version:bump",
+    "version:bump": "node scripts/smart-version-bump.mjs",
     "prepare": "node scripts/install-git-hooks.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs"
   },

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -13,6 +13,8 @@ const hookContents = `#!/bin/sh
 ${hookMarker}
 set -e
 
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 npm run precommit
 `;
 

--- a/scripts/smart-version-bump.mjs
+++ b/scripts/smart-version-bump.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const VERSION_FILES = new Set(["package.json", "package-lock.json"]);
+const VALID_BUMPS = new Set(["major", "minor", "patch", "none"]);
+
+const docsOnlyPatterns = [
+  /^README\.md$/i,
+  /^WHATSNEW\.md$/i,
+  /^CODE_OF_CONDUCT\.md$/i,
+  /^CONTRIBUTING\.md$/i,
+  /^SECURITY\.md$/i,
+  /^SUPPORT\.md$/i,
+  /^PRIVACY\.md$/i,
+  /^LICENSE$/i,
+];
+
+const minorPatterns = [
+  /^src\/App\.tsx$/,
+  /^src\/main\.tsx$/,
+  /^components\/.+\.tsx$/,
+  /^layout\/.+\.tsx$/,
+  /^index\.html$/,
+  /^public\/(?!metaData\/)/,
+];
+
+const patchPatterns = [
+  /^src\/.+\.(css|scss|ts)$/,
+  /^components\/.+\.(css|scss)$/,
+  /^layout\/.+\.(css|scss)$/,
+  /^styles\//,
+  /^utils\//,
+  /^tests\//,
+  /^scripts\//,
+  /^\.github\/workflows\//,
+  /^public\/metaData\//,
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^tsconfig\.json$/,
+  /^vite\.config\.ts$/,
+];
+
+const runGit = (args, options = {}) =>
+  execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+
+const getStagedFiles = () =>
+  runGit(["diff", "--cached", "--name-only", "--diff-filter=ACMRT", "-z"])
+    .split("\0")
+    .filter(Boolean);
+
+const readJsonFromGit = (ref) => {
+  try {
+    return JSON.parse(runGit(["show", ref]));
+  } catch {
+    return undefined;
+  }
+};
+
+const parseVersion = (version) => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error(`Unsupported semver version: ${version}`);
+  }
+
+  return match.slice(1).map(Number);
+};
+
+const nextVersion = (version, bump) => {
+  const [major, minor, patch] = parseVersion(version);
+
+  if (bump === "major") return `${major + 1}.0.0`;
+  if (bump === "minor") return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
+};
+
+const matchesAny = (file, patterns) => patterns.some((pattern) => pattern.test(file));
+const isDocsOnlyFile = (file) => matchesAny(file, docsOnlyPatterns);
+
+const inferBump = (files) => {
+  const nonVersionFiles = files.filter((file) => !VERSION_FILES.has(file));
+
+  if (nonVersionFiles.length === 0) return "none";
+  if (nonVersionFiles.every(isDocsOnlyFile)) return "none";
+  if (nonVersionFiles.some((file) => matchesAny(file, minorPatterns))) return "minor";
+  if (nonVersionFiles.some((file) => matchesAny(file, patchPatterns))) return "patch";
+
+  return "patch";
+};
+
+const updateJsonFile = (file, updater) => {
+  const json = JSON.parse(readFileSync(file, "utf8"));
+  updater(json);
+  writeFileSync(file, `${JSON.stringify(json, null, 2)}\n`);
+};
+
+const updatePackageLockVersion = (version) => {
+  if (!existsSync("package-lock.json")) {
+    return;
+  }
+
+  updateJsonFile("package-lock.json", (json) => {
+    json.version = version;
+    if (json.packages?.[""]) {
+      json.packages[""].version = version;
+    }
+  });
+
+  runGit(["add", "package-lock.json"], { stdio: "inherit" });
+};
+
+const main = () => {
+  const override = process.env.SITE_VERSION_BUMP?.toLowerCase();
+  if (override && !VALID_BUMPS.has(override)) {
+    throw new Error("SITE_VERSION_BUMP must be one of: major, minor, patch, none");
+  }
+
+  const files = getStagedFiles();
+  if (files.length === 0) {
+    console.log("Version bump skipped: no staged files.");
+    return;
+  }
+
+  const bump = override || inferBump(files);
+  if (bump === "none") {
+    console.log("Version bump skipped: no release-worthy staged changes.");
+    return;
+  }
+
+  const headPackageJson = readJsonFromGit("HEAD:package.json");
+  const stagedPackageJson = readJsonFromGit(":package.json");
+  if (
+    headPackageJson?.version &&
+    stagedPackageJson?.version &&
+    headPackageJson.version !== stagedPackageJson.version
+  ) {
+    const stagedPackageLockJson = readJsonFromGit(":package-lock.json");
+    if (
+      existsSync("package-lock.json") &&
+      (stagedPackageLockJson?.version !== stagedPackageJson.version ||
+        stagedPackageLockJson?.packages?.[""]?.version !== stagedPackageJson.version)
+    ) {
+      updatePackageLockVersion(stagedPackageJson.version);
+    }
+
+    console.log(`Version bump skipped: staged version is already ${stagedPackageJson.version}.`);
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+  const currentVersion = packageJson.version;
+  const newVersion = nextVersion(currentVersion, bump);
+
+  updateJsonFile("package.json", (json) => {
+    json.version = newVersion;
+  });
+
+  updatePackageLockVersion(newVersion);
+  runGit(["add", "package.json"], { stdio: "inherit" });
+  console.log(`Version bumped: ${currentVersion} -> ${newVersion} (${bump}).`);
+};
+
+try {
+  main();
+} catch (error) {
+  console.error(`Version bump failed: ${error.message}`);
+  process.exit(1);
+}

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -257,18 +257,6 @@
   transform: scale(1.025);
 }
 
-.darkProjectImage {
-  display: none;
-}
-
-:global(:root[data-theme="dark"]) .lightProjectImage {
-  display: none;
-}
-
-:global(:root[data-theme="dark"]) .darkProjectImage {
-  display: block;
-}
-
 .projectBody {
   display: flex;
   flex: 1;
@@ -357,6 +345,18 @@
   display: block;
   object-fit: cover;
   object-position: top center;
+}
+
+.darkProjectImage {
+  display: none;
+}
+
+:global(:root[data-theme="dark"]) .lightProjectImage {
+  display: none;
+}
+
+:global(:root[data-theme="dark"]) .darkProjectImage {
+  display: block;
 }
 
 .codePreview {


### PR DESCRIPTION
This pull request introduces automated versioning for the portfolio, setting the baseline to version 2.0.0 and adding a smart version bump script that runs as part of the pre-commit workflow. The version bumping logic is configurable and can be overridden for major, minor, patch, or no version changes. Additionally, documentation and configuration files have been updated to reflect these changes, and a small fix was made to the dark mode project image CSS.

**Automated Versioning and Tooling:**

* Introduced a new `scripts/smart-version-bump.mjs` script that inspects staged changes and determines the appropriate semantic version bump (major, minor, patch, or none) based on file patterns, with support for manual override via the `SITE_VERSION_BUMP` environment variable. The script also ensures that `package-lock.json` is kept in sync with `package.json` and stages it if necessary.
* Updated the `precommit` script in `package.json` to run quality checks followed by the new version bump script, and added a `precommit:checks` script for clarity.
* Set the initial site version to `2.0.0` in `package.json` to mark the new baseline for the portfolio.
* Added a `Versioning` section to `README.md` explaining the versioning strategy, the smart version bump tool, and how to override the bump type.
* Noted the new versioning system and baseline in `WHATSNEW.md`.

**Developer Experience Improvements:**

* Modified `.vscode/settings.json` to require explicit user action for organizing imports and fixing all issues on save, rather than running these actions automatically.
* Updated the pre-commit hook installer to set the `PATH` variable, improving compatibility with local environments.

**Styling Fix:**

* Moved the dark mode project image CSS rules to the correct location in `src/App.module.css` to ensure they are applied as intended. [[1]](diffhunk://#diff-b44f19f4ba65df4e29c72eb8fe6026f1a7df39ea1c0d642c271e1776698be4cbR350-R361) [[2]](diffhunk://#diff-b44f19f4ba65df4e29c72eb8fe6026f1a7df39ea1c0d642c271e1776698be4cbL260-L271)