### PR TITLE
Enhance Discord GMod Muter project description and add demo/repo labels for clarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manix84.github.io",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "manix84.github.io",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "classnames": "^2.5.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manix84.github.io",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,9 +73,11 @@ const compactProjects = [
   {
     title: "Discord GMod Muter",
     description:
-      "A Garry's Mod addon and Discord bot pairing for muting dead TTT players, with 100+ public forks across the companion tools.",
+      "A two-part Garry's Mod and Discord system: the game addon tells the server-hosted bot to mute dead TTT players for timed rounds.",
     demoUrl: "https://github.com/manix84/discord_gmod_bot",
+    demoLabel: "Discord bot",
     repoUrl: "https://github.com/manix84/discord_gmod_addon",
+    repoLabel: "GMod addon",
   },
   {
     title: "Chrome Utility Extensions",
@@ -315,10 +317,10 @@ const Home = () => {
                 <p>{project.description}</p>
                 <div className={st.projectLinks}>
                   <a href={project.demoUrl} target="_blank" rel="noreferrer">
-                    Open
+                    {"demoLabel" in project ? project.demoLabel : "Open"}
                   </a>
                   <a href={project.repoUrl} target="_blank" rel="noreferrer">
-                    Source
+                    {"repoLabel" in project ? project.repoLabel : "Source"}
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
This pull request updates the project to version 2.1.0 and improves the project showcase section by adding more descriptive labels and clarifying project descriptions. The most important changes are grouped below.

**Project showcase improvements:**

* Updated the description of the "Discord GMod Muter" project to better explain the two-part system and its function.
* Added `demoLabel` and `repoLabel` fields to the "Discord GMod Muter" project, making project links more descriptive.
* Updated the UI to display `demoLabel` and `repoLabel` for project links when available, falling back to default labels otherwise.

**Versioning:**

* Bumped the project version from 2.0.0 to 2.1.0 in `package.json` to reflect these enhancements.